### PR TITLE
add vault deployment

### DIFF
--- a/infras/helm-values/vault.yaml
+++ b/infras/helm-values/vault.yaml
@@ -1,0 +1,247 @@
+# Available parameters and their default values for the Vault chart.
+
+global:
+  psp:
+    enable: true
+    annotations: |
+      seccomp.security.alpha.kubernetes.io/allowedProfileNames: docker/default,runtime/default
+      apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+      seccomp.security.alpha.kubernetes.io/defaultProfileName:  runtime/default
+      apparmor.security.beta.kubernetes.io/defaultProfileName:  runtime/default
+
+injector:
+  enabled: true
+  replicas: 1
+  metrics:
+    enabled: true
+  image:
+    repository: "hashicorp/vault-k8s"
+    tag: "0.8.0"
+    pullPolicy: IfNotPresent
+  agentImage:
+    repository: "vault"
+    tag: "1.6.2"
+
+server:
+  # Resource requests, limits, etc. for the server cluster placement. This
+  # should map directly to the value of the resources field for a PodSpec.
+  # By default no direct resource request is made.
+
+  image:
+    repository: "vault"
+    tag: "1.6.2"
+    # Overrides the default Image Pull Policy
+    pullPolicy: IfNotPresent
+
+  # Configure the Update Strategy Type for the StatefulSet
+  # See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  updateStrategyType: "OnDelete"
+
+  resources: {}
+  # resources:
+  #   requests:
+  #     memory: 256Mi
+  #     cpu: 250m
+  #   limits:
+  #     memory: 256Mi
+  #     cpu: 250m
+
+  # Ingress allows ingress services to be created to allow external access
+  # from Kubernetes to access Vault pods.
+  # If deployment is on OpenShift, the following block is ignored.
+  # In order to expose the service, use the route section below
+  ingress:
+    enabled: false
+    labels: {}
+      # traffic: external
+    annotations: {}
+      # |
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+      #   or
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    hosts:
+      - host: chart-example.local
+        paths: []
+
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  # OpenShift only - create a route to expose the service
+  # The created route will be of type passthrough
+
+  readinessProbe:
+    enabled: true
+    # If you need to use a http path instead of the default exec
+    # path: /v1/sys/health?standbyok=true
+
+    # When a probe fails, Kubernetes will try failureThreshold times before giving up
+    failureThreshold: 2
+    # Number of seconds after the container has started before probe initiates
+    initialDelaySeconds: 5
+    # How often (in seconds) to perform the probe
+    periodSeconds: 5
+    # Minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    # Number of seconds after which the probe times out.
+    timeoutSeconds: 3
+  # Used to enable a livenessProbe for the pods
+  livenessProbe:
+    enabled: false
+    path: "/v1/sys/health?standbyok=true"
+    # When a probe fails, Kubernetes will try failureThreshold times before giving up
+    failureThreshold: 2
+    # Number of seconds after the container has started before probe initiates
+    initialDelaySeconds: 60
+    # How often (in seconds) to perform the probe
+    periodSeconds: 5
+    # Minimum consecutive successes for the probe to be considered successful after having failed
+    successThreshold: 1
+    # Number of seconds after which the probe times out.
+    timeoutSeconds: 3
+
+  # Used to set the sleep time during the preStop step
+  preStopSleepSeconds: 5
+
+  # Used to define commands to run after the pod is ready.
+  # This can be used to automate processes such as initialization
+  # or boostrapping auth methods.
+  postStart: []
+  # - /bin/sh
+  # - -c
+  # - /vault/userconfig/myscript/run.sh
+
+  # extraEnvironmentVars is a list of extra environment variables to set with the stateful set. These could be
+  # used to include variables required for auto-unseal.
+  extraEnvironmentVars: {}
+    # GOOGLE_REGION: global
+    # GOOGLE_PROJECT: myproject
+    # GOOGLE_APPLICATION_CREDENTIALS: /vault/userconfig/myproject/myproject-creds.json
+
+  # extraSecretEnvironmentVars is a list of extra environment variables to set with the stateful set.
+  # These variables take value from existing Secret objects.
+  extraSecretEnvironmentVars: []
+    # - envName: AWS_SECRET_ACCESS_KEY
+    #   secretName: vault
+    #   secretKey: AWS_SECRET_ACCESS_KEY
+
+  # extraVolumes is a list of extra volumes to mount. These will be exposed
+  # to Vault in the path `/vault/userconfig/<name>/`. The value below is
+  # an array of objects, examples are shown below.
+  extraVolumes: []
+    # - type: secret (or "configMap")
+    #   name: my-secret
+    #   path: null # default is `/vault/userconfig`
+
+  # volumes is a list of volumes made available to all containers. These are rendered
+  # via toYaml rather than pre-processed like the extraVolumes value.
+  # The purpose is to make it easy to share volumes between containers.
+  volumes: null
+  #   - name: plugins
+  #     emptyDir: {}
+
+  # volumeMounts is a list of volumeMounts for the main server container. These are rendered
+  # via toYaml rather than pre-processed like the extraVolumes value.
+  # The purpose is to make it easy to share volumes between containers.
+  volumeMounts: null
+  #   - mountPath: /usr/local/libexec/vault
+  #     name: plugins
+  #     readOnly: true
+
+
+  # Affinity Settings
+  # Commenting out or setting as empty the affinity variable, will allow
+  # deployment to single node services such as Minikube
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ template "vault.name" . }}
+              app.kubernetes.io/instance: "{{ .Release.Name }}"
+              component: server
+          topologyKey: kubernetes.io/hostname
+
+  # Toleration Settings for server pods
+  # This should be a multi-line string matching the Toleration array
+  # in a PodSpec.
+  tolerations: null
+
+  # nodeSelector labels for server pod assignment, formatted as a muli-line string.
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+  # Example:
+  # nodeSelector: |
+  #   beta.kubernetes.io/arch: amd64
+  nodeSelector: null
+
+  
+  # Enables a headless service to be used by the Vault Statefulset
+  service:
+    enabled: true
+    # clusterIP controls whether a Cluster IP address is attached to the
+    # Vault service within Kubernetes.  By default the Vault service will
+    # be given a Cluster IP address, set to None to disable.  When disabled
+    # Kubernetes will create a "headless" service.  Headless services can be
+    # used to communicate with pods directly through DNS instead of a round robin
+    # load balancer.
+    # clusterIP: None
+
+    # Configures the service type for the main Vault service.  Can be ClusterIP
+    # or NodePort.
+    #type: ClusterIP
+
+    # If type is set to "NodePort", a specific nodePort value can be configured,
+    # will be random if left blank.
+    #nodePort: 30000
+
+    # Port on which Vault server is listening
+    port: 8200
+    # Target port to which the service should be mapped to
+    targetPort: 8200
+    # Extra annotations for the service definition. This can either be YAML or a
+    # YAML-formatted multi-line templated string map of the annotations to apply
+    # to the service.
+    annotations: {}
+
+  # This configures the Vault Statefulset to create a PVC for data
+  # storage when using the file or raft backend storage engines.
+  # See https://www.vaultproject.io/docs/configuration/storage/index.html to know more
+  dataStorage:
+    enabled: true
+    # Size of the PVC created
+    size: 10Gi
+    # Location where the PVC will be mounted.
+    mountPath: "/vault/data"
+    # Name of the storage class to use.  If null it will use the
+    # configured default Storage Class.
+    storageClass: null
+    # Access Mode of the storage device being used for the PVC
+    accessMode: ReadWriteOnce
+    # Annotations to apply to the PVC
+    annotations: {}
+
+  # This configures the Vault Statefulset to create a PVC for audit
+  # logs.  Once Vault is deployed, initialized and unseal, Vault must
+  # be configured to use this for audit logs.  This will be mounted to
+  # /vault/audit
+  # See https://www.vaultproject.io/docs/audit/index.html to know more
+  auditStorage:
+    enabled: true
+    # Size of the PVC created
+    size: 2Gi
+    # Location where the PVC will be mounted.
+    mountPath: "/vault/audit"
+    # Name of the storage class to use.  If null it will use the
+    # configured default Storage Class.
+    storageClass: null
+    # Access Mode of the storage device being used for the PVC
+    accessMode: ReadWriteOnce
+    # Annotations to apply to the PVC
+    annotations: {}
+
+# Vault UI
+ui:
+  enabled: true

--- a/infras/init-resources.tf
+++ b/infras/init-resources.tf
@@ -15,6 +15,9 @@ resource "helm_release" "vault" {
   chart            = "vault"
   namespace        = "vault"
   create_namespace = true
+  values = [
+     file("helm-values/vault.yaml")
+  ]
 }
 
 resource "helm_release" "monitoring" {

--- a/infras/terraform.tfvars
+++ b/infras/terraform.tfvars
@@ -3,6 +3,6 @@ longhorn_enabled = true
 
 monitoring_enabled = true
 
-vault_enabled = false
+vault_enabled = true
 
 default_pool = "192.168.1.66-192.168.1.69"


### PR DESCRIPTION
Adding Vault deployment

```hcl
Terraform will perform the following actions:

  # helm_release.vault[0] will be created
  + resource "helm_release" "vault" {
      + atomic                     = false
      + chart                      = "vault"
      + cleanup_on_fail            = false
      + create_namespace           = true
      + dependency_update          = false
      + disable_crd_hooks          = false
      + disable_openapi_validation = false
      + disable_webhooks           = false
      + force_update               = false
      + id                         = (known after apply)
      + lint                       = false
      + max_history                = 0
      + metadata                   = (known after apply)
      + name                       = "vault"
      + namespace                  = "vault"
      + recreate_pods              = false
      + render_subchart_notes      = true
      + replace                    = false
      + repository                 = "https://helm.releases.hashicorp.com"
      + reset_values               = false
      + reuse_values               = false
      + skip_crds                  = false
      + status                     = "deployed"
      + timeout                    = 300
      + values                     = [
          + <<-EOT
                # Available parameters and their default values for the Vault chart.

                global:
                  psp:
                    enable: true
                    annotations: |
                      seccomp.security.alpha.kubernetes.io/allowedProfileNames: docker/default,runtime/default
                      apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
                      seccomp.security.alpha.kubernetes.io/defaultProfileName:  runtime/default
                      apparmor.security.beta.kubernetes.io/defaultProfileName:  runtime/default

                injector:
                  enabled: true
                  replicas: 1
                  metrics:
                    enabled: true
                  image:
                    repository: "hashicorp/vault-k8s"
                    tag: "0.8.0"
                    pullPolicy: IfNotPresent
                  agentImage:
                    repository: "vault"
                    tag: "1.6.2"

                server:
                  # Resource requests, limits, etc. for the server cluster placement. This
                  # should map directly to the value of the resources field for a PodSpec.
                  # By default no direct resource request is made.

                  image:
                    repository: "vault"
                    tag: "1.6.2"
                    # Overrides the default Image Pull Policy
                    pullPolicy: IfNotPresent

                  # Configure the Update Strategy Type for the StatefulSet
                  # See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
                  updateStrategyType: "OnDelete"

                  resources: {}
                  # resources:
                  #   requests:
                  #     memory: 256Mi
                  #     cpu: 250m
                  #   limits:
                  #     memory: 256Mi
                  #     cpu: 250m

                  # Ingress allows ingress services to be created to allow external access
                  # from Kubernetes to access Vault pods.
                  # If deployment is on OpenShift, the following block is ignored.
                  # In order to expose the service, use the route section below
                  ingress:
                    enabled: false
                    labels: {}
                      # traffic: external
                    annotations: {}
                      # |
                      # kubernetes.io/ingress.class: nginx
                      # kubernetes.io/tls-acme: "true"
                      #   or
                      # kubernetes.io/ingress.class: nginx
                      # kubernetes.io/tls-acme: "true"
                    hosts:
                      - host: chart-example.local
                        paths: []

                    tls: []
                    #  - secretName: chart-example-tls
                    #    hosts:
                    #      - chart-example.local

                  # OpenShift only - create a route to expose the service
                  # The created route will be of type passthrough

                  readinessProbe:
                    enabled: true
                    # If you need to use a http path instead of the default exec
                    # path: /v1/sys/health?standbyok=true

                    # When a probe fails, Kubernetes will try failureThreshold times before giving up
                    failureThreshold: 2
                    # Number of seconds after the container has started before probe initiates
                    initialDelaySeconds: 5
                    # How often (in seconds) to perform the probe
                    periodSeconds: 5
                    # Minimum consecutive successes for the probe to be considered successful after having failed
                    successThreshold: 1
                    # Number of seconds after which the probe times out.
                    timeoutSeconds: 3
                  # Used to enable a livenessProbe for the pods
                  livenessProbe:
                    enabled: false
                    path: "/v1/sys/health?standbyok=true"
                    # When a probe fails, Kubernetes will try failureThreshold times before giving up
                    failureThreshold: 2
                    # Number of seconds after the container has started before probe initiates
                    initialDelaySeconds: 60
                    # How often (in seconds) to perform the probe
                    periodSeconds: 5
                    # Minimum consecutive successes for the probe to be considered successful after having failed
                    successThreshold: 1
                    # Number of seconds after which the probe times out.
                    timeoutSeconds: 3

                  # Used to set the sleep time during the preStop step
                  preStopSleepSeconds: 5

                  # Used to define commands to run after the pod is ready.
                  # This can be used to automate processes such as initialization
                  # or boostrapping auth methods.
                  postStart: []
                  # - /bin/sh
                  # - -c
                  # - /vault/userconfig/myscript/run.sh

                  # extraEnvironmentVars is a list of extra environment variables to set with the stateful set. These could be
                  # used to include variables required for auto-unseal.
                  extraEnvironmentVars: {}
                    # GOOGLE_REGION: global
                    # GOOGLE_PROJECT: myproject
                    # GOOGLE_APPLICATION_CREDENTIALS: /vault/userconfig/myproject/myproject-creds.json

                  # extraSecretEnvironmentVars is a list of extra environment variables to set with the stateful set.
                  # These variables take value from existing Secret objects.
                  extraSecretEnvironmentVars: []
                    # - envName: AWS_SECRET_ACCESS_KEY
                    #   secretName: vault
                    #   secretKey: AWS_SECRET_ACCESS_KEY

                  # extraVolumes is a list of extra volumes to mount. These will be exposed
                  # to Vault in the path `/vault/userconfig/<name>/`. The value below is
                  # an array of objects, examples are shown below.
                  extraVolumes: []
                    # - type: secret (or "configMap")
                    #   name: my-secret
                    #   path: null # default is `/vault/userconfig`

                  # volumes is a list of volumes made available to all containers. These are rendered
                  # via toYaml rather than pre-processed like the extraVolumes value.
                  # The purpose is to make it easy to share volumes between containers.
                  volumes: null
                  #   - name: plugins
                  #     emptyDir: {}

                  # volumeMounts is a list of volumeMounts for the main server container. These are rendered
                  # via toYaml rather than pre-processed like the extraVolumes value.
                  # The purpose is to make it easy to share volumes between containers.
                  volumeMounts: null
                  #   - mountPath: /usr/local/libexec/vault
                  #     name: plugins
                  #     readOnly: true


                  # Affinity Settings
                  # Commenting out or setting as empty the affinity variable, will allow
                  # deployment to single node services such as Minikube
                  affinity: |
                    podAntiAffinity:
                      requiredDuringSchedulingIgnoredDuringExecution:
                        - labelSelector:
                            matchLabels:
                              app.kubernetes.io/name: {{ template "vault.name" . }}
                              app.kubernetes.io/instance: "{{ .Release.Name }}"
                              component: server
                          topologyKey: kubernetes.io/hostname

                  # Toleration Settings for server pods
                  # This should be a multi-line string matching the Toleration array
                  # in a PodSpec.
                  tolerations: null

                  # nodeSelector labels for server pod assignment, formatted as a muli-line string.
                  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
                  # Example:
                  # nodeSelector: |
                  #   beta.kubernetes.io/arch: amd64
                  nodeSelector: null


                  # Enables a headless service to be used by the Vault Statefulset
                  service:
                    enabled: true
                    # clusterIP controls whether a Cluster IP address is attached to the
                    # Vault service within Kubernetes.  By default the Vault service will
                    # be given a Cluster IP address, set to None to disable.  When disabled
                    # Kubernetes will create a "headless" service.  Headless services can be
                    # used to communicate with pods directly through DNS instead of a round robin
                    # load balancer.
                    # clusterIP: None

                    # Configures the service type for the main Vault service.  Can be ClusterIP
                    # or NodePort.
                    #type: ClusterIP

                    # If type is set to "NodePort", a specific nodePort value can be configured,
                    # will be random if left blank.
                    #nodePort: 30000

                    # Port on which Vault server is listening
                    port: 8200
                    # Target port to which the service should be mapped to
                    targetPort: 8200
                    # Extra annotations for the service definition. This can either be YAML or a
                    # YAML-formatted multi-line templated string map of the annotations to apply
                    # to the service.
                    annotations: {}

                  # This configures the Vault Statefulset to create a PVC for data
                  # storage when using the file or raft backend storage engines.
                  # See https://www.vaultproject.io/docs/configuration/storage/index.html to know more
                  dataStorage:
                    enabled: true
                    # Size of the PVC created
                    size: 10Gi
                    # Location where the PVC will be mounted.
                    mountPath: "/vault/data"
                    # Name of the storage class to use.  If null it will use the
                    # configured default Storage Class.
                    storageClass: null
                    # Access Mode of the storage device being used for the PVC
                    accessMode: ReadWriteOnce
                    # Annotations to apply to the PVC
                    annotations: {}

                  # This configures the Vault Statefulset to create a PVC for audit
                  # logs.  Once Vault is deployed, initialized and unseal, Vault must
                  # be configured to use this for audit logs.  This will be mounted to
                  # /vault/audit
                  # See https://www.vaultproject.io/docs/audit/index.html to know more
                  auditStorage:
                    enabled: true
                    # Size of the PVC created
                    size: 2Gi
                    # Location where the PVC will be mounted.
                    mountPath: "/vault/audit"
                    # Name of the storage class to use.  If null it will use the
                    # configured default Storage Class.
                    storageClass: null
                    # Access Mode of the storage device being used for the PVC
                    accessMode: ReadWriteOnce
                    # Annotations to apply to the PVC
                    annotations: {}

                # Vault UI
                ui:
                  enabled: true
            EOT,
        ]
      + verify                     = false
      + version                    = "0.9.1"
      + wait                       = true
    }

Plan: 1 to add, 0 to change, 0 to destroy.

```