### PR TITLE
fix: grafana auto-inject unused env var

### DIFF
--- a/system/templates/monitoring.yaml
+++ b/system/templates/monitoring.yaml
@@ -38,6 +38,7 @@ spec:
               enabled: false
         grafana:
           enabled: true
+          enableServiceLinks: false
           image:
             tag: 8.3.1
           persistence:


### PR DESCRIPTION
This causing new Grafana pod could not be create due to Jaeger's environment variables are in wrong format for parsing.