### PR TITLE
fix: typo in grub.cfg

### DIFF
--- a/metal/roles/pxe-server/templates/grub.cfg.j2
+++ b/metal/roles/pxe-server/templates/grub.cfg.j2
@@ -3,6 +3,6 @@ set timeout=1
 menuentry '{{ iso_url | basename | splitext | first }} (PXE)' {
     linux vmlinuz \
         ip=dhcp \
-        inst.ks=http://{{ ansible_default_ipv4.address }}/init-config/${net_default_mac}.inst.ks
+        inst.ks=http://{{ ansible_default_ipv4.address }}/init-config/${net_default_mac}.ks
     initrd initrd.img
 }

--- a/metal/roles/wake/tasks/main.yml
+++ b/metal/roles/wake/tasks/main.yml
@@ -6,4 +6,4 @@
 - name: Wait for the servers to comes up
   ignore_unreachable: yes
   wait_for_connection:
-    timeout: 900
+    timeout: 600


### PR DESCRIPTION
# Intent

Fix typo in grub.cfg from copy-pasta