### PR TITLE
chore: let's be ignorance to the installation/upgrade

### DIFF
--- a/metal/roles/cilium/tasks/main.yml
+++ b/metal/roles/cilium/tasks/main.yml
@@ -1,8 +1,14 @@
-- name: Install Cilium
-  ansible.builtin.command: cilium install
+- name: Install/Upgrade Cilium
+  block:
+  - name: Install Cillium
+    ansible.builtin.command: cilium install
+  rescue:
+  - name: Upgrade Cillium
+    ansible.builtin.command: cilium upgrade
 
 - name: Enable Hubble
   ansible.builtin.command: cilium hubble enable --ui
+  ignore_errors: true
 
 - name: Wait for Cilium installation
   ansible.builtin.command: cilium status --wait


### PR DESCRIPTION
Since cillium-cli doesn't have the idempotence when instaling itself and enabling hubble, this will:
- catch if the installation failed and try with the upgrade instead (treat as the first installation has been done)
- ignore the hubble's error and let the `cilium status --wait` command does its job