### PR TITLE
docs: update path so it would resolve nicely on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ See the [docs](https://humble.maibaloc.com) for detailed information on the arch
 
 For getting started:
 
-- [Try it out locally](/getting-started/development/) without any hardware.
-- [Deploy on real hardware](/getting-started/production/overview) for production workload.
+- [Try it out locally](https://humble.maibaloc.com/getting-started/development/) without any hardware.
+- [Deploy on real hardware](https://humble.maibaloc.com/getting-started/production/overview) for production workload.
 
 ## Acknowledgements
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,10 @@
 --8<--
-README.md
+README.md:1:20
+--8<--
+
+- [Try it out locally](/getting-started/development/) without any hardware.
+- [Deploy on real hardware](/getting-started/production/overview) for production workload.
+
+--8<--
+README.md::25
 --8<--


### PR DESCRIPTION
The path would lead to 404 page on GitHub. This is a small fix to have it works perfectly on both the doc page and GitHub.