### PR TITLE
chore: clean up mimir and old config

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+### What this PR does / why we need it
+
+### Which issue this PR fixes
+
+*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
+
+- fixes #

--- a/system/templates/monitoring.yaml
+++ b/system/templates/monitoring.yaml
@@ -53,10 +53,6 @@ spec:
                   resources:
                     requests:
                       storage: 2Gi
-            remoteWrite:
-              - url: http://mimir-nginx/api/v1/push
-                headers:
-                  X-Scope-OrgID: humble
           server:
             enableServiceLinks: false
 
@@ -114,55 +110,12 @@ spec:
                 foldersFromFilesStructure: true
               annotations:
                 k8s-sidecar-target-directory: "/tmp/dashboards/kubernetes"
-            datasources:
-              defaultDatasourceEnabled: false
           additionalDataSources:
             - name: loki
               type: loki
               editable: false
               url: http://loki-stack:3100
               isDefault: false
-            - name: Mimir
-              isDefault: true
-              type: prometheus
-              url: http://mimir-nginx/prometheus
-              basicAuth: false
-              jsonData:
-                httpHeaderName1: X-Scope-OrgID
-              secureJsonData:
-                httpHeaderValue1: humble
-          plugins:
-          - yesoreyeram-boomtheme-panel
-          - flant-statusmap-panel
-          - vonage-status-panel
-          - natel-discrete-panel
-          - grafana-polystat-panel
-          - digiapulssi-breadcrumb-panel
-          - macropower-analytics-panel
-
         alertmanager:
           enabled: false
-          config:
-            global:
-              resolve_timeout: 5m
-            route:
-              group_by: ['alertname', 'job', 'ops']
-              group_wait: 30s
-              group_interval: 5m
-              repeat_interval: 2h
-              receiver: "yutaops-webhook"
-              routes:
-              - match:
-                  ops: yuta
-                receiver: 'yutaops-webhook'
-              - match:
-                  ops: argo-events
-                receiver: 'argo-eventsource'
-            receivers:
-            - name: 'yutaops-webhook'
-              webhook_configs:
-                - url: 'http://yutaops-webhook.apps.svc.cluster.local:8501/webhook'
-            - name: 'argo-eventsource'
-              webhook_configs:
-                - url: 'http://webhook-demo-eventsource-svc.argoworkflow.svc.cluster.local:12000/demo'
 {{- end }}

--- a/system/values-prod.yaml
+++ b/system/values-prod.yaml
@@ -4,7 +4,7 @@ longhorn:
 
 # Observability
 mimir:
-  enabled: true
+  enabled: false
 
 monitoring:
   enabled: true


### PR DESCRIPTION
### What this PR does / why we need it

### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- disables mimir
- clean up old configuration
- add PR template
- disable remote-write from Prometheus
- add default datasource (Prometheus)
