### PR TITLE
feat: update Kubernetes to 1.29.0

### DIFF
--- a/metal/roles/k3s/defaults/main.yml
+++ b/metal/roles/k3s/defaults/main.yml
@@ -1,4 +1,4 @@
-k3s_version: v1.28.3+k3s2
+k3s_version: v1.29.0+k3s1
 k3s_config_file: /etc/rancher/k3s/config.yaml
 k3s_token_file: /etc/rancher/node/password
 k3s_service_file: /etc/systemd/system/k3s.service


### PR DESCRIPTION
### What this PR does / why we need it

### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*

- update Kubernetes to 1.29.0
